### PR TITLE
Add basic tests via GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [pull-request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Build site
-      run: docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material build --verbose
+      run: docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: Test
+
+on: [pull-request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Build site
+      run: docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material build --verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # selfhostedshow/wiki
 
+![CI Status Badge](https://github.com/selfhostedshow/wiki/workflows/Test/badge.svg)
+
 This repository contains the backend for the [Self-Hosted](https://selfhosted.show) podcast wiki.
 
 ## Usage
@@ -12,7 +14,7 @@ Add the following line to your mkdocs.yml:
 Mount the folder where your mkdocs.yml resides as a volume into /docs:
 
 * Start development server on http://localhost:8000
-  
+
     `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`
 
 * Build documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,4 +38,6 @@ markdown_extensions:
 plugins:
   - search
   - minify:
-      minify_html: true      
+      minify_html: true
+
+strict: true


### PR DESCRIPTION
Use GitHub actions to ensure PRs build correctly.

Docker command copied from `README.md`, and `-v` added to ensure verbose output.

Doesn't appear to be running on the commits on this repo, but output can be seen on [my fork](https://github.com/RealOrangeOne/ssh-wiki/actions)