### PR TITLE
Change GitHub actions event

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
`push` seems to only be called for pushes to the main repo, which isn't something we do. `pull_request` however should be called on any PR.

The proof this works is whether this PR has a CI task which runs successfully. (Which it seems to :tada:)