### PR TITLE
Also run CI on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
       run: docker-compose pull
 
     - name: Build site
-      run: docker-compose run wiki build
+      run: docker-compose run wiki build -v


### PR DESCRIPTION
Extension of #9 

This ensures that merges are also run against CI, so status badges are updated properly