### PR TITLE
Updated broken link to selfhosted/wiki github repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome 
 
-Here you will find an [open source](link), living and breathing repository of resources that we talk about on the Self Hosted podcast. You can help us help you by submitting PRs on Github to improve this documentation or fix mistakes.
+Here you will find an [open source](https://github.com/selfhostedshow/wiki), living and breathing repository of resources that we talk about on the Self Hosted podcast. You can help us help you by submitting PRs on Github to improve this documentation or fix mistakes.
 
 ## About the show
 


### PR DESCRIPTION
Bad link in the live version of the wiki's Welcome section, located on the index page.