### PR TITLE
Fix Fireside Footer Link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ extra:
     - icon: 'fontawesome/brands/twitter'
       link: 'https://twitter.com/selfhostedshow'
     - icon: 'fontawesome/solid/fire'
-      link: 'https://fireside.com'
+      link: 'https://selfhosted.show/'
     - icon: 'fontawesome/solid/microphone'
       link: 'https://pocketcasts.com'
     - icon: 'fontawesome/solid/graduation-cap'


### PR DESCRIPTION
The Fireside icon is currently linked to the website of a manufacturer for fireplaces.
I fixed the link to go to Self Hosted's Fireside site.