### PR TITLE
Only run strict mode on CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       run: docker-compose build
 
     - name: Build site
-      run: docker-compose run wiki build -v
+      run: docker-compose run wiki build --verbose --strict
 
     - name: Build production container
       run: docker build --tag docker.pkg.github.com/${GITHUB_REPOSITORY,,}/prod:latest -f prod/Dockerfile .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       run: docker-compose build
 
     - name: Build site
-      run: docker-compose run wiki build -v
+      run: docker-compose run wiki build --verbose --strict
 
     - name: Build production container
       run: docker build -f prod/Dockerfile .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,6 @@ FROM squidfunk/mkdocs-material:latest
 COPY requirements.txt /docs/requirements.txt
 
 RUN pip install -U -r /docs/requirements.txt
+
+# Work around for https://github.com/squidfunk/mkdocs-material/pull/1712
+CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,3 @@ FROM squidfunk/mkdocs-material:latest
 COPY requirements.txt /docs/requirements.txt
 
 RUN pip install -U -r /docs/requirements.txt
-
-# Work around for https://github.com/squidfunk/mkdocs-material/pull/1712
-CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,5 +37,3 @@ plugins:
   - search
   - minify:
       minify_html: true
-
-strict: true


### PR DESCRIPTION
It's no longer possible to run `mkdocs serve` in strict mode under docker.

https://github.com/mkdocs/mkdocs/issues/2108