### PR TITLE
Update link to linuxserver.io reverse proxy guide

### DIFF
--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -9,7 +9,7 @@ The content is provided "as is" without warranty of any kind, either expressed o
 Things here might include:
 
 ### Where to start<br>
-  * [Linuxserver.io - Let's Encrypt, Nginx & Reverse Proxy Starter Guide - 2019 Edition](https://blog.linuxserver.io/2019/04/25/letsencrypt-nginx-starter-guide/#nextcloudsubdomainreverseproxyexample) - How to get started with docker, docker-compose, nginx as reverse proxy + SSL and cloud services (Nextcloud, Plex, Ombi, Heimdall)
+  * [Linuxserver.io - SWAG setup](https://docs.linuxserver.io/general/swag) - How to get started with docker, docker-compose, nginx as reverse proxy + SSL and cloud services (Nextcloud, Plex, Ombi, Heimdall)
   * [25 Basic Docker Commands for Beginners](http://codeopolis.com/posts/25-basic-docker-commands-for-beginners/) - A docker command cheat sheet to help get you started with docker.
   * [SmartHomeBeginner](https://www.smarthomebeginner.com/) - How to setup your own complete home server using docker-compose.
 ### Hardware


### PR DESCRIPTION
The article is now outdated since the linuxserver.io team changed  their container name to `swag` instead `letsencrypt`.
An updated version of this article is now included in their docs.