### PR TITLE
Remove dev ref from contributing.md internal link correction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ This Wiki is intended to be for _anyone_ -- regardless of expertise -- who is in
 - Add the changed files to your commit and commit the changes to your fork: `git add file1.md file2.md && git commit -m 'updated x,y,z'`
 - Push your commit to your fork: `git push origin master`
 - [Build the wiki locally](https://github.com/selfhostedshow/wiki/blob/master/CONTRIBUTING.md#build-locally) and check that your added content renders properly in your local build.
-- On Github's web interface go to your fork and set the branch to "dev". Then submit a pull request by selecting "New Pull Request".
+- On Github's web interface go to your fork and set the branch to `<branch_name>`. Then submit a pull request by selecting "New Pull Request".
 
 Not sure what to write about, take a look at our [issues](https://github.com/selfhostedshow/wiki/issues).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ This Wiki is intended to be for _anyone_ -- regardless of expertise -- who is in
 - Make changes as desired to the files in the repository on your machine.
 - Add the changed files to your commit and commit the changes to your fork: `git add file1.md file2.md && git commit -m 'updated x,y,z'`
 - Push your commit to your fork: `git push origin master`
-- [Build the wiki locally](https://github.com/selfhostedshow/wiki/blob/master/CONTRIBUTING.md#build-locally) and check that your added content renders properly in your local build.
+- [Build the wiki locally](https://wiki.selfhosted.show/wiki/contributing#build-locally) and check that your added content renders properly in your local build.
 - On Github's web interface go to your fork and set the branch to `<branch_name>`. Then submit a pull request by selecting "New Pull Request".
 
 Not sure what to write about, take a look at our [issues](https://github.com/selfhostedshow/wiki/issues).


### PR DESCRIPTION
This makes two changes.

1. Remove `dev` reference for making a pull request
2. keep internal page link local to the wiki site. Previously it took the user off wiki.selfhosted.show and went to GitHub.com....