### PR TITLE
Add MkDocs specific Markdown guides to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,7 @@ Not sure what to write about, take a look at our [issues](https://github.com/sel
 
 ## Other Resources
 
-For help with Markdown:  
-[MkDocs Cheatsheet](https://3os.org/markdownCheatSheet/welcome/)  
-[MkDocs -- Admonition](https://3os.org/markdownCheatSheet/admonition/)  
+<!--- For help with Markdown: --->  
+[MdDocs-Material Reference](https://squidfunk.github.io/mkdocs-material/reference/admonitions/)  
 [Markdown -- Github Help](https://help.github.com/en/github/writing-on-github)  
-[Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)  
+[Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)    

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Not sure what to write about, take a look at our [issues](https://github.com/sel
 ## Other Resources
 
 For help with Markdown:  
-[MkDocs Cheatsheet ](https://3os.org/markdownCheatSheet/welcome/)  
+[MkDocs Cheatsheet](https://3os.org/markdownCheatSheet/welcome/)  
 [MkDocs -- Admonition](https://3os.org/markdownCheatSheet/admonition/)  
 [Markdown -- Github Help](https://help.github.com/en/github/writing-on-github)  
 [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,8 @@ Not sure what to write about, take a look at our [issues](https://github.com/sel
 
 ## Other Resources
 
-For help with Markdown:
-
-[Markdown -- Github Help](https://help.github.com/en/github/writing-on-github)
-
-[Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
+For help with Markdown:  
+[MkDocs Cheatsheet ](https://3os.org/markdownCheatSheet/welcome/)  
+[MkDocs -- Admonition](https://3os.org/markdownCheatSheet/admonition/)  
+[Markdown -- Github Help](https://help.github.com/en/github/writing-on-github)  
+[Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)  


### PR DESCRIPTION
This adds two links. These links are cheatsheets more specific to MkDocs.