### PR TITLE
Fix rendering of codeblocks

### DIFF
--- a/docs/home-automation/home-assistant/supervisor-addons/android-debug-bridge/adb.md
+++ b/docs/home-automation/home-assistant/supervisor-addons/android-debug-bridge/adb.md
@@ -8,7 +8,7 @@ This guide walks you though how to configure Android Debug Bridge for controllin
 
 Initially you will need to install the add-on through the Home Assistant Supervisor Add-on Store. Once the Add-on is installed you will need to configure your devices as per the example below. 
 
- ```Config
+```Config
     devices:
     - 1.2.3.4
     - 4.3.2.1


### PR DESCRIPTION
Leading whitespace caused start of code block to not be detected in wiki. Further codeblocks were rendered incorrectly.

(I don't know why the last line got changed too. I've only edited this in the online editor and didn't change anything else