### PR TITLE
Custom page support allows the replacement of default canonical tag with url from author.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,6 @@ The site will then be output into the `site/` directory.
 
 ### Contribution Template
 
-The file `contribution-template.md` has been provided as a sample and possible starting point. It is located along with this `README` file. Feel free to copy and use the template.
+The file `contribution-template.md` has been provided as a sample and possible starting point. It is located along with this `README` file. Feel free to copy and use this template.
+
+The file `canonocal-template.md` has been provided as a sample and possible starting point if you wish to cross-post an article from your own blog. It is located along with this `README` file. Feel free to copy and use this template.

--- a/canonocal-template.md
+++ b/canonocal-template.md
@@ -1,0 +1,32 @@
+---
+template: canonical.html
+canonical: https://some-url-to-original-page
+title: Overrides file name in the left pane of the site
+summary: Provide a brief summary of the page/article.
+date: yyyy-mm-dd
+authors:
+  - Author Name 1
+  - Author Name 2
+---
+
+# If this heading is present it overrides the heading in the body of this document. If omitted. frontmatter "title:" is used
+
+## Header for TOC which appears on the right pane of the page
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+### Sub header also appears in right pane. Slightly indent compared to ## header
+Bogus content two
+
+!!! note "Unused attributes included in frontmatter for forward compatibility"
+    date: Currently not used. But present if this is enabled in the future.
+
+    summary: Same as for date.
+
+    authors: Same as for date.
+
+!!! tip
+    Per guidelines. Punctuation should not be used in the Title: for headings.
+
+!!! info
+    If you want to know how to create the note and info boxes. See [here](https://3os.org/markdownCheatSheet/admonition/)
+
+    Another useful [link](https://3os.org/markdownCheatSheet/welcome/)

--- a/custom/canonical.html
+++ b/custom/canonical.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{%- block site_meta %}
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% if page and page.is_homepage %}<meta name="description" content="{{ config['site_description'] }}">{% endif %}
+  {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
+  {% if page and page.meta.canonical_url %}
+    <link rel="canonical" href="{{ page.meta.canonical_url }}">
+  {% else %}
+    {% if page and page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
+  {% endif %}
+  {% if config.site_favicon %}<link rel="shortcut icon" href="{{ config.site_favicon|url }}">
+  {% else %}<link rel="shortcut icon" href="{{ 'img/favicon.ico'|url }}">
+  {% endif %}
+{%- endblock %}
+
+{%- block content %}
+  {% if page and page.meta.canonical_url %} 
+      <center>1. Originally posted on: <a href="{{ page.meta.canonical_url}}">
+        {{ page.meta.canonical_url.split("//")[-1].split("/")[0] }}</a>
+      </center>
+      <center>2. Originally posted on: <a href="{{ page.meta.canonical_url}}">
+        {{ page.meta.canonical_url.split(":")[0] }}://{{ page.meta.canonical_url.split("//")[-1].split("/")[0] }}/</a>
+      </center>
+  {% endif %}
+  {{ super() }}
+  {% if page and page.meta.canonical_url %} 
+      <center>Originally posted: <a href="{{ page.meta.canonical_url}}">
+        {{ page.meta.canonical_url.split(":")[0] }}://{{ page.meta.canonical_url.split("//")[-1].split("/")[0] }}/</a></center>
+  {% endif %}
+{%- endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://wiki.selfhosted.show
 repo_url: https://github.com/selfhostedshow/wiki
 theme:
   name: 'material'
+  custom_dir: custom
   font:
     text: 'Ubuntu'
     code: 'Ubuntu Mono'


### PR DESCRIPTION
Prevents Google Search engine confusing content that has been added, but which has an existing home.

Sample with link both top and bottom. Top shows two options.

Add canonical-template.md

rename meta.canonocal to meta.canonocal_url
More inline with existing naming.
Provide two options for listing the url on the page.

Update README.md with canonical template information.

If you wish to see this in action. Update a post with the following items in your meta data
```yaml
---
template: canonical.html
canonical_url: http[your-link]
---
```

If accept this closes #112 