### PR TITLE
Self Hosted Show Storage Leaderboard

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,16 @@ This wiki was created by the audience of the [Self-Hosted podcast](https://selfh
 
 The show is your gateway to self-hosting all the things. Discover new software to take control of cloud services and own your data. Learn how you can take steps to free yourself from the agenda of large corporates and business models designed to sell your information. We help you unlock the power of Linux and Open Source.
 
+## SSH Storage Leaderboard
+
+| Rank | Guest            | Storage | Episode Timestamp                       | Notes |
+|------|------------------|---------|-----------------------------------------|-------|
+| #1   | Wendell Wilson   | 1 PB    | [#2 15:12](https://selfhosted.show/2)   | ZFS and Beehive |
+| #2   | JDM              | 500 TB  | [#21 37:01](https://selfhosted.show/21) | Split between Unraid boxes |
+| #3   | Jeff Geerling    | 84 TB   | [#41 29:51](https://selfhosted.show/41) | 60 TB unallocated for projects |
+| #4   | Jake Howard      | 14 TB   | [#42 34:45](https://selfhosted.show/42) | Was hoping for lowest (golf) score! |
+| #5   | Paulus Schoutsen | 8 TB    | [#45 20:12](https://selfhosted.show/45) | Creator of the Home Assistant Project |
+
 ## Our other podcasts
 
 * [Linux Action News](https://linuxactionnews.com/) - A weekly Linux news and analysis podcast


### PR DESCRIPTION
Originally I was aiming to have a chart of usable vs raw for storage. I was unable to do this. Inconsistency of how the question was asked and answered resulted in me totaling the referenced storage from the user. These notes should probably live with the PR for future discussion.

I do not care and will change if:
* You think the location in the wiki is wrong
* You don't want notes, or
* Think the storage amount should be counted differently

Methodology:
* Listening to podcasts at 4X speed - god help me.
* [This script](https://gist.github.com/tolson-vkn/870793b9020418daa4753c9beca51edd) with basic verification of listened numbers. 

Guest Notes (NA storage and declared storage)

Alan Pope 13 - NA
Andries Faassen 9 - NA
Brent Gervais 51 52 62 69 - NA
chzbacon 69 - NA
chzbacon 61 - NA
Drew DeVore 61 - NA
Elan Feingold 4 - NA
Jake Howard 42 - Says only 4 in usable but 8 through raid1 total mentioned 14TB raw possible
JDM_WAAAT 21 - Fat stacks
Jeff Geerling 41 - He answers 24TB in use but has 60TB sitting on the shelf, so taking 84TB
Jonathan Panozzo 25 - NA
Matt from Adventurous Way 53 - NA, should ask in discord
Michael Dominick 26 - NA
Wes Payne 26 - NA
Morgan Peterman 56 48 18 - NA
Paulus Schoutsen 45 - NA
Wendell Wilson 2 14 - Stated he has 20TB at home, but could make 1PB pooling all his resources together
Wes Payne 68 - NA


![image](https://user-images.githubusercontent.com/14153338/165661984-17651617-49b0-4189-a939-8a74d46ed14f.png)
