### PR TITLE
Add Techno Tim. Correct Wendell's notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,12 +12,13 @@ The show is your gateway to self-hosting all the things. Discover new software t
 
 | Rank | Guest            | Storage | Episode Timestamp                       | Notes                                                 |
 | ---- | ---------------- | ------- | --------------------------------------- | ----------------------------------------------------- |
-| #1   | Wendell Wilson   | 1 PB    | [#2 15:12](https://selfhosted.show/2)   | ZFS and Beehive                                       |
+| #1   | Wendell Wilson   | 1 PB    | [#2 15:12](https://selfhosted.show/2)   | ZFS on FreeBSD with Beehive                           |
 | #2   | JDM              | 500 TB  | [#21 37:01](https://selfhosted.show/21) | Split between Unraid boxes                            |
 | #3   | Jeff Geerling    | 84 TB   | [#41 29:51](https://selfhosted.show/41) | 60 TB unallocated for projects                        |
 | #4   | Fuzzy Mistborn   | 70 TB   | [#70 11:28](https://selfhosted.show/70) | Debate about whether or not to count off-site storage |
-| #5   | Jake Howard      | 14 TB   | [#42 34:45](https://selfhosted.show/42) | Was hoping for lowest (golf) score!                   |
-| #6   | Paulus Schoutsen | 8 TB    | [#45 20:12](https://selfhosted.show/45) | Creator of the Home Assistant Project                 |
+| #5   | TechnoTim        | 40 TB   | [#73 16:20](https://selfhosted.show/73) | Tim's storage on his disk shelf                       |
+| #6   | Jake Howard      | 14 TB   | [#42 34:45](https://selfhosted.show/42) | Was hoping for lowest (golf) score!                   |
+| #7   | Paulus Schoutsen | 8 TB    | [#45 20:12](https://selfhosted.show/45) | Creator of the Home Assistant Project                 |
 
 ## Our other podcasts
 


### PR DESCRIPTION
Techno Tim's self explanatory. Back when I generated this way back
I meant to call out Wendell as running FreeBSD, but wrote beehive.
The story of him moving from FreeNAS to FreeBSD was the interesting
note. Additionally it seems weird to couple ZFS and beehive, makes more
sense to couple ZFS and an OS.