### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,16 +10,19 @@ The show is your gateway to self-hosting all the things. Discover new software t
 
 ## SSH Storage Leaderboard
 
-| Rank | Guest            | Storage | Episode Timestamp                       | Notes                                                 |
-| ---- | ---------------- | ------- | --------------------------------------- | ----------------------------------------------------- |
-| #1   | Wendell Wilson   | 1 PB    | [#2 15:12](https://selfhosted.show/2)   | ZFS and Beehive                                       |
-| #2   | JDM              | 500 TB  | [#21 37:01](https://selfhosted.show/21) | Split between Unraid boxes                            |
-| #3   | Jeff Geerling    | 84 TB   | [#41 29:51](https://selfhosted.show/41) | 60 TB unallocated for projects                        |
-| #4   | Fuzzy Mistborn   | 70 TB   | [#70 11:28](https://selfhosted.show/70) | Debate about whether or not to count off-site storage |
-| #5   | Techno Tim       | 40 TB   | [#73 16:22](https://selfhosted.show/73) | Kubernetes and #100DaysOfHomeLab initiative           |
-| #6   | Jscar_Hawk       | 20 TB   | [#74 36:34](https://selfhosted.show/74) | All the Pis                                           |
-| #7   | Jake Howard      | 14 TB   | [#42 34:45](https://selfhosted.show/42) | Was hoping for lowest (golf) score!                   |
-| #8   | Paulus Schoutsen | 8 TB    | [#45 20:12](https://selfhosted.show/45) | Creator of the Home Assistant Project                 |
+| Rank | Guest                                                 | Storage | Episode Timestamp                         | Notes                                                 |
+| ---- | ----------------------------------------------------- | ------- | ----------------------------------------- | ----------------------------------------------------- |
+| #1   | [Wendell Wilson](https://level1techs.com/about-us)    | 1 PB    | [#2 15:12](https://selfhosted.show/2)     | ZFS and Beehive                                       |
+| #2   | [JDM](https://www.serverbuilds.net/)                  | 500 TB  | [#21 37:01](https://selfhosted.show/21)   | Split between Unraid boxes                            |
+| #3   | [Jeff Geerling](https://www.jeffgeerling.com/)        | 84 TB   | [#41 29:51](https://selfhosted.show/41)   | 60 TB unallocated for projects                        |
+| #4   | Fuzzy Mistborn                                        | 70 TB   | [#70 11:28](https://selfhosted.show/70)   | Debate about whether or not to count off-site storage |
+| #5   | [Wolfgang](https://www.youtube.com/@WolfgangsChannel) | 65 TB   | [#111 16:38](https://selfhosted.show/111) | Using two pools. Video editing/production from NAS    |
+| #6   | [Techno Tim](https://technotim.live/)                 | 40 TB   | [#73 16:22](https://selfhosted.show/73)   | Kubernetes and #100DaysOfHomeLab initiative           |
+| #7   | [Jscar_Hawk](https://jscar-hawk.com/)                 | 20 TB   | [#74 36:34](https://selfhosted.show/74)   | All the Pis                                           |
+| #8   | Jake Howard                                           | 14 TB   | [#42 34:45](https://selfhosted.show/42)   | Was hoping for lowest (golf) score!                   |
+| #9   | [Paulus Schoutsen](https://github.com/balloob)        | 8 TB    | [#45 20:12](https://selfhosted.show/45)   | Creator of the Home Assistant Project                 |
+
+_Storage numbers are provided as raw storage capacity; as it should never be a penalty to have parity._
 
 ## Our other podcasts
 


### PR DESCRIPTION
Wolfgang added to leader board.

---

Surprised to not see this yet.

I added links to the guest's medias. Mostly because I was wondering: Do I put Wolfgang or do I put Wolfgang's channel? But if I don't put `'s channel` what if people want to go to his channel as he mentioned that as his contact point in episode.

Will remove if preferred. I think how the wiki currently does hyperlink text it won't look disruptive. 

 